### PR TITLE
Apollo client setup

### DIFF
--- a/lib/withApollo.tsx
+++ b/lib/withApollo.tsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import Head from 'next/head'
+import { ApolloProvider } from '@apollo/react-hooks'
+import { ApolloClient } from 'apollo-client'
+import { InMemoryCache } from 'apollo-cache-inmemory'
+import { HttpLink } from 'apollo-link-http'
+import fetch from 'isomorphic-unfetch'
+
+let globalApolloClient: any = null
+
+/**
+ * Creates and provides the apolloContext
+ * to a next.js PageTree. Use it by wrapping
+ * your PageComponent via HOC pattern.
+ * @param {Function|Class} PageComponent
+ * @param {Object} [config]
+ * @param {Boolean} [config.ssr=true]
+ */
+export function withApollo(PageComponent: any, { ssr = true } = {}) {
+  const WithApollo = ({ apolloClient, apolloState, ...pageProps }:{apolloClient: any, apolloState:any}) => {
+    const client = apolloClient || initApolloClient(apolloState)
+    return (
+      <ApolloProvider client={client}>
+        <PageComponent {...pageProps} />
+      </ApolloProvider>
+    )
+  }
+
+  // Set the correct displayName in development
+  if (process.env.NODE_ENV !== 'production') {
+    const displayName =
+      PageComponent.displayName || PageComponent.name || 'Component'
+
+    if (displayName === 'App') {
+      console.warn('This withApollo HOC only works with PageComponents.')
+    }
+
+    WithApollo.displayName = `withApollo(${displayName})`
+  }
+
+  if (ssr || PageComponent.getInitialProps) {
+    WithApollo.getInitialProps = async (ctx:any) => {
+      const { AppTree } = ctx
+
+      // Initialize ApolloClient, add it to the ctx object so
+      // we can use it in `PageComponent.getInitialProp`.
+      const apolloClient = (ctx.apolloClient = initApolloClient())
+
+      // Run wrapped getInitialProps methods
+      let pageProps = {}
+      if (PageComponent.getInitialProps) {
+        pageProps = await PageComponent.getInitialProps(ctx)
+      }
+
+      // Only on the server:
+      if (typeof window === 'undefined') {
+        // When redirecting, the response is finished.
+        // No point in continuing to render
+        if (ctx.res && ctx.res.finished) {
+          return pageProps
+        }
+
+        // Only if ssr is enabled
+        if (ssr) {
+          try {
+            // Run all GraphQL queries
+            const { getDataFromTree } = await import('@apollo/react-ssr')
+            await getDataFromTree(
+              <AppTree
+                pageProps={{
+                  ...pageProps,
+                  apolloClient,
+                }}
+              />
+            )
+          } catch (error) {
+            // Prevent Apollo Client GraphQL errors from crashing SSR.
+            // Handle them in components via the data.error prop:
+            // https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-query-data-error
+            console.error('Error while running `getDataFromTree`', error)
+          }
+
+          // getDataFromTree does not call componentWillUnmount
+          // head side effect therefore need to be cleared manually
+          Head.rewind()
+        }
+      }
+
+      // Extract query data from the Apollo store
+      const apolloState = apolloClient.cache.extract()
+
+      return {
+        ...pageProps,
+        apolloState,
+      }
+    }
+  }
+
+  return WithApollo
+}
+
+/**
+ * Always creates a new apollo client on the server
+ * Creates or reuses apollo client in the browser.
+ * @param  {Object} initialState
+ */
+function initApolloClient(initialState?: any) {
+  // Make sure to create a new client for every server-side request so that data
+  // isn't shared between connections (which would be bad)
+  if (typeof window === 'undefined') {
+    return createApolloClient(initialState)
+  }
+
+  // Reuse client on the client-side
+  if (!globalApolloClient) {
+    globalApolloClient = createApolloClient(initialState)
+  }
+
+  return globalApolloClient
+}
+
+/**
+ * Creates and configures the ApolloClient
+ * @param  {Object} [initialState={}]
+ */
+function createApolloClient(initialState = {}) {
+  // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
+  return new ApolloClient({
+    ssrMode: typeof window === 'undefined', // Disables forceFetch on the server (so queries are only run once)
+    link: new HttpLink({
+      uri: 'AWS URI????', // Server URL (must be absolute)
+      credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
+      fetch,
+    }),
+    cache: new InMemoryCache().restore(initialState),
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,36 @@
         }
       }
     },
+    "@apollo/react-common": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
+      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
+      "requires": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-hooks": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.5.tgz",
+      "integrity": "sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==",
+      "requires": {
+        "@apollo/react-common": "^3.1.4",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-ssr": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.5.tgz",
+      "integrity": "sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==",
+      "requires": {
+        "@apollo/react-common": "^3.1.4",
+        "@apollo/react-hooks": "^3.1.5",
+        "tslib": "^1.10.0"
+      }
+    },
     "@apollographql/apollo-tools": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
@@ -1524,6 +1554,11 @@
         "@types/node": "*"
       }
     },
+    "@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -1681,6 +1716,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "requires": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
     "@wry/equality": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
@@ -1827,6 +1871,15 @@
         }
       }
     },
+    "apollo-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
+      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
+      "requires": {
+        "apollo-utilities": "^1.3.4",
+        "tslib": "^1.10.0"
+      }
+    },
     "apollo-cache-control": {
       "version": "0.10.1-alpha.0",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.10.1-alpha.0.tgz",
@@ -1834,6 +1887,33 @@
       "requires": {
         "apollo-server-env": "^2.4.4-alpha.0",
         "graphql-extensions": "^0.12.1-alpha.0"
+      }
+    },
+    "apollo-cache-inmemory": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
+      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
+      "requires": {
+        "apollo-cache": "^1.3.5",
+        "apollo-utilities": "^1.3.4",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "apollo-client": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
+      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
+      "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.3.5",
+        "apollo-link": "^1.0.0",
+        "apollo-utilities": "1.3.4",
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.0"
       }
     },
     "apollo-datasource": {
@@ -1897,6 +1977,26 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable-ts": "^0.8.21"
+      }
+    },
+    "apollo-link-http": {
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
+      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "apollo-link-http-common": "^0.2.16",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-server-caching": {
@@ -5252,6 +5352,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "optimism": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
+      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "requires": {
+        "@wry/context": "^0.4.0"
       }
     },
     "os-browserify": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "@apollo/react-hooks": "^3.1.5",
+    "@apollo/react-ssr": "^3.1.5",
     "@material-ui/core": "^4.9.14",
     "@material-ui/styles": "^4.9.14",
     "@types/react-redux": "^7.1.8",
+    "apollo-cache-inmemory": "^1.6.6",
+    "apollo-client": "^2.6.10",
+    "apollo-link-http": "^1.5.17",
     "apollo-server-lambda": "^2.13.1",
     "graphql": "^15.0.0",
     "isomorphic-unfetch": "3.0.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,14 @@
 // import Link from 'next/link'
 import Layout from '../components/Layout'
 import { withRedux } from '../lib/withRedux'
+import { withApollo } from '../lib/withApollo'
 import { useSelector, useDispatch } from 'react-redux'
+import { compose } from 'redux'
+
 
 
 const IndexPage = () => {
+  //state selecting hook
   const selectedState = useSelector((state: any) => state.counter)
   console.log(selectedState)
   // const dispatch = useDispatch()
@@ -17,4 +21,5 @@ const IndexPage = () => {
   )
 }
 
-export default withRedux(IndexPage)
+// This may need to change, but basically compose works by combining wrapper functions into one
+export default compose(withApollo, withRedux)(IndexPage)


### PR DESCRIPTION
**Problem**
- Need to add Apollo Client and make sure it plays nicely with Redux
**Solution**
- Added a "withApollo" file to lib, alongside Redux. We can have two of them as long as we use the built in "compose" function from Redux, to combine them when exporting a component. Note that either of these are only necessary in components where we want to read/upate state, or trigger GraphQL queries.
**To test**
- Currently, run npm run dev and see the page still load. We cannot test GraphQL queries yet